### PR TITLE
Do not fail on invalid audio files; skip them

### DIFF
--- a/dcase_task2/prepare_spectrograms.py
+++ b/dcase_task2/prepare_spectrograms.py
@@ -130,7 +130,12 @@ if __name__ == "__main__":
             spectrogram = proc.process(aug_audio_file)
         except:
             print("Audio clipping failed! Computing spectrogram on original audio.")
-            spectrogram = proc.process(file)
+            try:
+                spectrogram = proc.process(file)
+            except Exception:
+                print("Could not process %s. Ignoring." % file)
+                os.remove(aug_audio_file)
+                continue
 
         # fix spectrogram dimensions
         if spectrogram.ndim == 2:


### PR DESCRIPTION
Some of the test files seem to be empty (0b0427e2.wav, 6ea0099f.wav, b39975f5.wav) and cannot be processed by `prepare_spectrograms.py`, or at least not on my machine. They are marked as `None,Ignore` in the `test_post_competition.csv` file anyway. This skips the files instead of exiting the script.