### PR TITLE
Allow to specify the number of GPUs to use

### DIFF
--- a/dcase_task2/run_experiment.sh
+++ b/dcase_task2/run_experiment.sh
@@ -2,12 +2,22 @@
 
 # $1 ... experimental tag used for screen
 # $2 ... experimental call
+# $3 ... number of GPUs, defaults to 4
 
-for fold in 1 2 3 4
-do
-    gpu=$((fold - 1))
-    cmd="THEANO_FLAGS=\"device=cuda$gpu\" $2 --fold $fold"
-    screen_name="$1_$fold"
+tag="$1"
+command="$2"
+num_gpus="${3:-4}"
+gpu=0
+for fold in {1..4}; do
+    cmd="THEANO_FLAGS=\"device=cuda$gpu\" $command --fold $fold"
     echo $cmd
-    screen -d -m -S "$screen_name" bash -c "$cmd"
+    screen -d -m -S "${tag}_${fold}" bash -c "$cmd"
+    ((gpu++))
+    if [ $gpu == $num_gpus ]; then
+        # wait for current screens to finish
+        while screen -ls | grep --quiet -e "${tag}_[1234]"; do
+            sleep 10
+        done
+        gpu=0
+    fi
 done

--- a/dcase_task2/run_experiment_set.py
+++ b/dcase_task2/run_experiment_set.py
@@ -5,15 +5,6 @@ import argparse
 from dcase_task2.lasagne_wrapper.utils import BColors
 
 
-def open_screens(screen_name="dcase"):
-    """
-    Check if there are open dcase screens
-    (that's not a very nice way to check this!)
-    """
-    ret = os.popen('screen -ls').read()
-    return screen_name in ret
-
-
 cols = BColors()
 
 # define model to train
@@ -30,13 +21,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run entire set of experiments.')
     parser.add_argument('--experiment_set', help='Select set of experiments to run (pretrain, finetune or all)',
                         type=str, default='all')
+    parser.add_argument('--num_gpus', help='How many GPUs to spread the experiments over (1..4, while 4 is the default)',
+                        type=int, default=4)
     args = parser.parse_args()
 
     # commands for pre-training the models
     pre_train_commands = []
     for model, data in MODELS_DATA_DICT.iteritems():
-        cmd = './run_experiment.sh dcase "python2 train.py --model models/%s.py --data tut18T2-%s --max_len 3000"'
-        pre_train_commands.append(cmd % (model, data))
+        cmd = './run_experiment.sh dcase "python2 train.py --model models/%s.py --data tut18T2-%s --max_len 3000" %d'
+        pre_train_commands.append(cmd % (model, data, args.num_gpus))
 
     # commands for fine-tuning the models with self-verification
     fine_tune_commands = []
@@ -54,6 +47,7 @@ if __name__ == "__main__":
             cmd += ' --ini_params params_foldX_it%d --max_len 3000' % i
             cmd += ' --train_file train_self_verified_it%d.csv --tag it%d' % (i, i + 1)
             cmd += ' --fine_tune"'
+            cmd += ' %d' % args.num_gpus
             cmd = cmd.replace("foldX", "%d")
             fine_tune_commands.append(cmd)
 
@@ -72,13 +66,6 @@ if __name__ == "__main__":
     cmd_idx = 0
     n_commands = len(commands)
     while cmd_idx < n_commands:
-
-        # wait a while and check for open screens
-        # (I know ... that's not very nice!)
-        time.sleep(30)
-        if open_screens():
-            continue
-
         print(cols.print_colored("Running experiment (%d / %d)" % (cmd_idx + 1, n_commands), cols.WARNING))
         print(commands[cmd_idx])
         os.system(commands[cmd_idx])


### PR DESCRIPTION
This adds a `--num_gpus` flag to `run_experiment_set.py` to allow running the experiments with fewer than 4 GPUs. It adapts the `run_experiment.sh` helper script accordingly, and moves all the waiting logic into the latter.